### PR TITLE
Make paddedBuffer less error-prone

### DIFF
--- a/scripts/generateProofs.js
+++ b/scripts/generateProofs.js
@@ -2,16 +2,12 @@ const { MerkleTree } = require('merkletreejs')
 const keccak256 = require('keccak256')
 const wl = require('./wl.json')
 const fs = require('fs');
-
-function paddedBuffer(addr){
-    const buf = Buffer.from(addr.substr(2).padStart(32*2, "0"), "hex")
-    return Buffer.concat([buf]);
-}
+const { paddedBuffer } = require('./utils');
 
 async function main() {
-    const tree = new MerkleTree(wl.map(x => paddedBuffer(x)), keccak256, { sort: true })
+    const tree = new MerkleTree(wl.map(paddedBuffer), keccak256, { sort: true })
     const proofs = {}
-    for(const address of wl){
+    for (const address of wl) {
         const leaf = paddedBuffer(address)
         const proof = tree.getHexProof(leaf)
         proofs[address.toLowerCase()]=proof

--- a/scripts/getWLproof.js
+++ b/scripts/getWLproof.js
@@ -2,14 +2,10 @@ const { MerkleTree } = require('merkletreejs')
 const keccak256 = require('keccak256')
 const wl = require('./wl.json')
 const ethers = require('ethers');
-
-function paddedBuffer(addr){
-    const buf = Buffer.from(addr.substr(2).padStart(32*2, "0"), "hex")
-    return Buffer.concat([buf]);
-}
+const { paddedBuffer } = require('./utils');
 
 async function mint(addressToMint) {
-    const tree = new MerkleTree(wl.map(x => paddedBuffer(x)), keccak256, { sort: true })
+    const tree = new MerkleTree(wl.map(paddedBuffer), keccak256, { sort: true })
     const leaf = paddedBuffer(addressToMint)
     const proof = tree.getHexProof(leaf)
     console.log("proof:", proof)


### PR DESCRIPTION
Make paddedBuffer less error-prone by strictly checking the input address length & copying it to a pre-created 32-byte-long null buffer instead of using `.padStart()`

\+ some code deduplication & cleanup